### PR TITLE
Fallback to `Intel`

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -93,7 +93,8 @@ async function installUnityEditor(unityHubPath, installPath, unityVersion, unity
         let arguments = `install --version ${unityVersion} --changeset ${unityVersionChangeset}`
         if (process.platform === 'darwin') {
             if (parseInt(unityVersion) > 2020) {
-                arguments += ` --architecture arm64`
+                // This is where we would set it to `arm64` but the progressive CPU lightmapper is not supported. And there is no GPU
+                arguments += ` --architecture x86_64`
             }
             else {
                 arguments += ` --architecture x86_64`


### PR DESCRIPTION
See https://issuetracker-mig.prd.it.unity3d.com/issues/unable-to-fall-back-to-cpu-lightmapper-dot-errors-in-the-console-when-opening-a-project-on-a-virtual-machine